### PR TITLE
Add subtle anime.js animations to web player

### DIFF
--- a/src/components/ChatSection.css
+++ b/src/components/ChatSection.css
@@ -14,6 +14,8 @@
   min-height: 0;
   position: relative;
   margin: 0 auto;
+  opacity: 0;
+  transform: translateX(20px);
 }
 
 .close-button-wrapper {

--- a/src/components/ChatSection.tsx
+++ b/src/components/ChatSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { animate as anime } from 'animejs'
 import './ChatSection.css'
 
 interface Message {
@@ -14,6 +15,7 @@ interface ChatSectionProps {
 const ChatSection = ({ height }: ChatSectionProps) => {
   const [messages, setMessages] = useState<Message[]>([])
   const [inputValue, setInputValue] = useState('')
+  const sectionRef = useRef<HTMLDivElement>(null)
 
   const handleSendMessage = () => {
     if (inputValue.trim()) {
@@ -34,9 +36,36 @@ const ChatSection = ({ height }: ChatSectionProps) => {
   }
 
   const chatStyle = height ? { height: `${height}px` } : {}
-  
+
+  // Slide in the chat section when it mounts
+  useEffect(() => {
+    if (sectionRef.current) {
+      anime(sectionRef.current, {
+        translateX: [20, 0],
+        opacity: [0, 1],
+        duration: 500,
+        easing: 'easeOutQuad'
+      })
+    }
+  }, [])
+
+  // Animate new messages subtly
+  useEffect(() => {
+    if (messages.length) {
+      const el = document.querySelector('.chat-message:last-child')
+      if (el) {
+        anime(el, {
+          translateY: [20, 0],
+          opacity: [0, 1],
+          duration: 500,
+          easing: 'easeOutQuad'
+        })
+      }
+    }
+  }, [messages])
+
   return (
-    <div className="chat-section" style={chatStyle}>
+    <div className="chat-section" ref={sectionRef} style={chatStyle}>
       {/* Close button */}
       <div className="close-button-wrapper">
         <div className="close-button">

--- a/src/components/MenuBar.css
+++ b/src/components/MenuBar.css
@@ -7,6 +7,8 @@
   gap: 30px;
   min-height: 60px;
   max-height: 60px;
+  opacity: 0;
+  transform: translateY(-10px);
 }
 
 .left-side {
@@ -78,14 +80,11 @@
   position: absolute;
   top: 50%;
   left: 0;
-  transform: translateY(-50%);
+  transform: translateY(-50%) scale(0.95);
   z-index: 1;
-  transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
-.home-button:hover .home-hovered {
-  opacity: 0.74;
-}
 
 .more-videos-button {
   width: 45px;
@@ -135,14 +134,11 @@
   position: absolute;
   top: 50%;
   left: 0;
-  transform: translateY(-50%);
+  transform: translateY(-50%) scale(0.95);
   z-index: 1;
-  transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
-.more-videos-button:hover .more-videos-hovered {
-  opacity: 0.74;
-}
 
 .more-videos-hovered span,
 .home-hovered span {

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate as anime, createTimeline, stagger } from 'animejs'
 import './MenuBar.css'
 
 interface MenuBarProps {
@@ -6,10 +8,51 @@ interface MenuBarProps {
 }
 
 const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
+  const barRef = useRef<HTMLDivElement>(null)
+
+  // Staggered entrance to showcase anime.js timelines
+  useEffect(() => {
+    if (barRef.current) {
+      const buttons = barRef.current.querySelectorAll('button')
+      const tl = createTimeline()
+      tl
+        .add(barRef.current, {
+          opacity: [0, 1],
+          translateY: [-10, 0],
+          duration: 500,
+          easing: 'easeOutQuad'
+        })
+        .add(
+          buttons,
+          {
+            opacity: [0, 1],
+            translateY: [-10, 0],
+            delay: stagger(100),
+            easing: 'easeOutQuad'
+          },
+          '-=300'
+        )
+    }
+  }, [])
+
+  const animateHover = (el: HTMLElement | null, show: boolean) => {
+    if (!el) return
+    anime(el, {
+      opacity: show ? 0.74 : 0,
+      scale: show ? [0.95, 1] : [1, 0.95],
+      duration: 300,
+      easing: 'easeOutQuad'
+    })
+  }
+
   return (
-    <div className="menu-bar">
+    <div className="menu-bar" ref={barRef}>
       <div className="left-side">
-        <button className="home-button">
+        <button
+          className="home-button"
+          onMouseEnter={(e) => animateHover(e.currentTarget.querySelector('.home-hovered'), true)}
+          onMouseLeave={(e) => animateHover(e.currentTarget.querySelector('.home-hovered'), false)}
+        >
           <svg className="home-icon" width="47" height="45" viewBox="0 0 47 45" fill="none" xmlns="http://www.w3.org/2000/svg">
             <g opacity="0.74" filter="url(#filter0_ddiiii_1_19104)">
               <rect x="3" y="3" width="41" height="39" rx="5" fill="#484848" fillOpacity="0.82"/>
@@ -61,7 +104,11 @@ const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
           </div>
         </button>
         
-        <button className="more-videos-button">
+        <button
+          className="more-videos-button"
+          onMouseEnter={(e) => animateHover(e.currentTarget.querySelector('.more-videos-hovered'), true)}
+          onMouseLeave={(e) => animateHover(e.currentTarget.querySelector('.more-videos-hovered'), false)}
+        >
           <svg className="more-videos-icon" width="45" height="45" viewBox="0 0 45 45" fill="none" xmlns="http://www.w3.org/2000/svg">
             <g opacity="0.74" filter="url(#filter0_ddiiii_1_19081)">
               <rect x="3" y="3" width="38.9679" height="39" rx="5" fill="#484848" fillOpacity="0.82"/>
@@ -114,8 +161,8 @@ const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
         </button>
       </div>
       
-      <button 
-        className={`chat-button ${isChatVisible ? 'active' : ''}`} 
+      <button
+        className={`chat-button ${isChatVisible ? 'active' : ''}`}
         onClick={onChatToggle}
       >
         <svg width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/VideoControls.css
+++ b/src/components/VideoControls.css
@@ -9,6 +9,8 @@
   justify-content: center;
   align-items: center;
   gap: 12px;
+  opacity: 0;
+  transform: translateY(10px);
 }
 
 .video-progress {

--- a/src/components/VideoControls.tsx
+++ b/src/components/VideoControls.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate as anime } from 'animejs'
 import './VideoControls.css'
 
 interface VideoControlsProps {
@@ -6,8 +8,34 @@ interface VideoControlsProps {
 }
 
 const VideoControls = ({ isPlaying, onTogglePlayPause }: VideoControlsProps) => {
+  const controlsRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // Fade in controls on mount
+  useEffect(() => {
+    if (controlsRef.current) {
+      anime(controlsRef.current, {
+        opacity: [0, 1],
+        translateY: [10, 0],
+        duration: 600,
+        easing: 'easeOutQuad'
+      })
+    }
+  }, [])
+
+  const handleClick = () => {
+    onTogglePlayPause()
+    if (buttonRef.current) {
+      anime(buttonRef.current, {
+        scale: [1, 0.9, 1],
+        duration: 300,
+        easing: 'easeInOutSine'
+      })
+    }
+  }
+
   return (
-    <div className="video-controls">
+    <div className="video-controls" ref={controlsRef}>
       <div className="video-progress">
         <svg width="1422" height="2" viewBox="0 0 1422 2" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M1.70755 1H1420.96" stroke="#4D413F" strokeWidth="2" strokeLinecap="round"/>
@@ -32,8 +60,8 @@ const VideoControls = ({ isPlaying, onTogglePlayPause }: VideoControlsProps) => 
           </svg>
         </div>
       </div>
-      
-      <button className="play-pause-button" onClick={onTogglePlayPause}>
+
+      <button className="play-pause-button" ref={buttonRef} onClick={handleClick}>
         {isPlaying ? (
           // Pause icon (two bars) - taller and perfectly centered
           <svg width="48" height="24" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/VideoPlayer.css
+++ b/src/components/VideoPlayer.css
@@ -7,6 +7,8 @@
   overflow: hidden;
   position: relative;
   margin: 0 auto; /* Center the video player when it's constrained */
+  opacity: 0;
+  transform: scale(0.97);
 }
 
 .video-player::before {
@@ -24,4 +26,17 @@
   position: absolute;
   top: 0;
   left: 0;
+}
+
+.playing-indicator {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  opacity: 0.6;
+  pointer-events: none;
 }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate as anime } from 'animejs'
 import './VideoPlayer.css'
 
 interface VideoPlayerProps {
@@ -5,25 +7,48 @@ interface VideoPlayerProps {
 }
 
 const VideoPlayer = ({ isPlaying }: VideoPlayerProps) => {
+  const playerRef = useRef<HTMLDivElement>(null)
+  const indicatorRef = useRef<HTMLDivElement>(null)
+
+  // Subtle entrance animation for the player
+  useEffect(() => {
+    if (playerRef.current) {
+      anime(playerRef.current, {
+        opacity: [0, 1],
+        scale: [0.97, 1],
+        duration: 800,
+        easing: 'easeOutQuad'
+      })
+    }
+  }, [])
+
+  // Pulsing indicator that showcases anime.js looping capabilities
+  useEffect(() => {
+    if (isPlaying && indicatorRef.current) {
+      const animation = anime(indicatorRef.current, {
+        opacity: [0.6, 1],
+        scale: [1, 1.05],
+        easing: 'easeInOutSine',
+        direction: 'alternate',
+        loop: true,
+        duration: 700
+      })
+
+      return () => {
+        animation.pause()
+      }
+    }
+  }, [isPlaying])
+
   return (
-    <div className="video-player">
-      <img 
-        className="tv-placeholder" 
-        src="https://placehold.co/1432x807/333333/ffffff?text=Video+Player" 
-        alt="Video Player Placeholder" 
+    <div className="video-player" ref={playerRef}>
+      <img
+        className="tv-placeholder"
+        src="https://placehold.co/1432x807/333333/ffffff?text=Video+Player"
+        alt="Video Player Placeholder"
       />
-      {/* You can add a play indicator overlay here if needed */}
       {isPlaying && (
-        <div className="playing-indicator" style={{
-          position: 'absolute',
-          top: '10px',
-          right: '10px',
-          background: 'rgba(0,0,0,0.7)',
-          color: 'white',
-          padding: '4px 8px',
-          borderRadius: '4px',
-          fontSize: '12px'
-        }}>
+        <div ref={indicatorRef} className="playing-indicator">
           Playing
         </div>
       )}


### PR DESCRIPTION
## Summary
- Animate video player entrance and add pulsing playing indicator using anime.js
- Fade in controls with play button bounce
- Stagger menu bar buttons and animate chat/message panels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3926e53708325b4ffab38925983be