### PR TITLE
Add subtle anime.js animations to player

### DIFF
--- a/src/components/ChatSection.css
+++ b/src/components/ChatSection.css
@@ -12,9 +12,10 @@
   flex-direction: column;
   gap: 12px;
   min-height: 0;
-  position: relative;
-  margin: 0 auto;
-}
+    position: relative;
+    margin: 0 auto;
+    opacity: 0;
+  }
 
 .close-button-wrapper {
   display: flex;

--- a/src/components/ChatSection.tsx
+++ b/src/components/ChatSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { animate } from 'animejs'
 import './ChatSection.css'
 
 interface Message {
@@ -14,6 +15,19 @@ interface ChatSectionProps {
 const ChatSection = ({ height }: ChatSectionProps) => {
   const [messages, setMessages] = useState<Message[]>([])
   const [inputValue, setInputValue] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const messagesRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      animate(containerRef.current, {
+        translateX: [40, 0],
+        opacity: [0, 1],
+        easing: 'easeOutQuad',
+        duration: 400
+      })
+    }
+  }, [])
 
   const handleSendMessage = () => {
     if (inputValue.trim()) {
@@ -35,8 +49,21 @@ const ChatSection = ({ height }: ChatSectionProps) => {
 
   const chatStyle = height ? { height: `${height}px` } : {}
   
+  useEffect(() => {
+    if (messagesRef.current) {
+      const last = messagesRef.current.lastElementChild
+      if (last) {
+        animate(last as Element, {
+          translateX: [50, 0],
+          opacity: [0, 1],
+          easing: 'easeOutQuad'
+        })
+      }
+    }
+  }, [messages])
+
   return (
-    <div className="chat-section" style={chatStyle}>
+    <div className="chat-section" style={chatStyle} ref={containerRef}>
       {/* Close button */}
       <div className="close-button-wrapper">
         <div className="close-button">
@@ -47,7 +74,7 @@ const ChatSection = ({ height }: ChatSectionProps) => {
       </div>
 
       {/* Messages container */}
-      <div className="messages-container">
+      <div className="messages-container" ref={messagesRef}>
         {messages.map((message) => (
           <div key={message.id} className={`chat-message ${message.isOwn ? 'right' : 'left'}`}>
             <div className={`message-bubble ${message.isOwn ? 'green' : 'blue'}`}>

--- a/src/components/MenuBar.css
+++ b/src/components/MenuBar.css
@@ -17,6 +17,10 @@
   gap: 30px;
 }
 
+.menu-bar button {
+  opacity: 0;
+}
+
 .home-button,
 .more-videos-button,
 .chat-button {

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate, stagger } from 'animejs'
 import './MenuBar.css'
 
 interface MenuBarProps {
@@ -6,8 +8,22 @@ interface MenuBarProps {
 }
 
 const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
+  const menuBarRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (menuBarRef.current) {
+      const buttons = menuBarRef.current.querySelectorAll('button')
+      animate(buttons, {
+        opacity: [0, 1],
+        translateY: [-8, 0],
+        easing: 'easeOutQuad',
+        delay: stagger(80)
+      })
+    }
+  }, [])
+
   return (
-    <div className="menu-bar">
+    <div className="menu-bar" ref={menuBarRef}>
       <div className="left-side">
         <button className="home-button">
           <svg className="home-icon" width="47" height="45" viewBox="0 0 47 45" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/VideoControls.tsx
+++ b/src/components/VideoControls.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate } from 'animejs'
 import './VideoControls.css'
 
 interface VideoControlsProps {
@@ -6,13 +8,48 @@ interface VideoControlsProps {
 }
 
 const VideoControls = ({ isPlaying, onTogglePlayPause }: VideoControlsProps) => {
+  const progressRef = useRef<HTMLDivElement>(null)
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const progressAnim = useRef<ReturnType<typeof animate> | null>(null)
+
+  useEffect(() => {
+    if (progressRef.current && progressBarRef.current) {
+      const width = progressBarRef.current.clientWidth - 19
+      progressAnim.current = animate(progressRef.current, {
+        translateX: width,
+        duration: 30000,
+        easing: 'linear',
+        autoplay: false
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    if (progressAnim.current) {
+      if (isPlaying) {
+        progressAnim.current.play()
+      } else {
+        progressAnim.current.pause()
+      }
+    }
+
+    if (buttonRef.current) {
+      animate(buttonRef.current, {
+        scale: [0.9, 1],
+        easing: 'spring(1, 80, 10, 0)',
+        duration: 500
+      })
+    }
+  }, [isPlaying])
+
   return (
     <div className="video-controls">
-      <div className="video-progress">
+      <div className="video-progress" ref={progressBarRef}>
         <svg width="1422" height="2" viewBox="0 0 1422 2" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M1.70755 1H1420.96" stroke="#4D413F" strokeWidth="2" strokeLinecap="round"/>
         </svg>
-        <div className="video-position">
+        <div className="video-position" ref={progressRef}>
           <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
             <g filter="url(#filter0_d_1_19743)">
               <ellipse cx="6.38295" cy="6.38295" rx="6.38295" ry="6.38295" transform="matrix(-1 0 0 1 15.811 0.617065)" fill="#6A7967"/>
@@ -32,8 +69,8 @@ const VideoControls = ({ isPlaying, onTogglePlayPause }: VideoControlsProps) => 
           </svg>
         </div>
       </div>
-      
-      <button className="play-pause-button" onClick={onTogglePlayPause}>
+
+      <button className="play-pause-button" onClick={onTogglePlayPause} ref={buttonRef}>
         {isPlaying ? (
           // Pause icon (two bars) - taller and perfectly centered
           <svg width="48" height="24" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/VideoPartyScreen.css
+++ b/src/components/VideoPartyScreen.css
@@ -33,6 +33,10 @@
   min-height: 0;
 }
 
+.horizontal-wrapper.chat-closed {
+  justify-content: center;
+}
+
 .media-items {
   flex: 1;
   padding: 14px 20px;

--- a/src/components/VideoPartyScreen.tsx
+++ b/src/components/VideoPartyScreen.tsx
@@ -39,21 +39,17 @@ const VideoPartyScreen = () => {
     <div className="netflix-party-screen">
       <div className={`screen-container ${isChatVisible ? 'chat-visible' : 'chat-hidden'}`}>
         <MenuBar onChatToggle={toggleChat} isChatVisible={isChatVisible} />
-        
-        {isChatVisible ? (
-          <div className="horizontal-wrapper">
-            <div className="media-items" ref={mediaItemsRef}>
-              <VideoPlayer isPlaying={isPlaying} />
-              <VideoControls isPlaying={isPlaying} onTogglePlayPause={togglePlayPause} />
-            </div>
-            <ChatSection height={chatHeight} />
-          </div>
-        ) : (
-          <div className="media-items fullscreen">
+
+        <div className={`horizontal-wrapper ${isChatVisible ? 'chat-open' : 'chat-closed'}`}>
+          <div
+            className={`media-items ${isChatVisible ? '' : 'fullscreen'}`}
+            ref={mediaItemsRef}
+          >
             <VideoPlayer isPlaying={isPlaying} />
             <VideoControls isPlaying={isPlaying} onTogglePlayPause={togglePlayPause} />
           </div>
-        )}
+          {isChatVisible && <ChatSection height={chatHeight} />}
+        </div>
       </div>
     </div>
   )

--- a/src/components/VideoPlayer.css
+++ b/src/components/VideoPlayer.css
@@ -1,13 +1,14 @@
 .video-player {
-  width: 100%;
-  max-width: calc(72vh * 16 / 9); /* Increased from 60vh to 72vh for 20% bigger */
-  box-shadow: 5px 5px 13px rgba(102, 102, 102, 0.90);
-  background: #000;
-  border-radius: 8px;
-  overflow: hidden;
-  position: relative;
-  margin: 0 auto; /* Center the video player when it's constrained */
-}
+    width: 100%;
+    max-width: calc(72vh * 16 / 9); /* Increased from 60vh to 72vh for 20% bigger */
+    box-shadow: 5px 5px 13px rgba(102, 102, 102, 0.90);
+    background: #000;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    margin: 0 auto; /* Center the video player when it's constrained */
+    opacity: 0;
+  }
 
 .video-player::before {
   content: "";

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+import { animate } from 'animejs'
 import './VideoPlayer.css'
 
 interface VideoPlayerProps {
@@ -5,25 +7,57 @@ interface VideoPlayerProps {
 }
 
 const VideoPlayer = ({ isPlaying }: VideoPlayerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const indicatorRef = useRef<HTMLDivElement>(null)
+  const indicatorAnim = useRef<ReturnType<typeof animate> | null>(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      animate(containerRef.current, {
+        opacity: [0, 1],
+        scale: [0.96, 1],
+        easing: 'easeOutQuad',
+        duration: 600
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    indicatorAnim.current?.cancel()
+    if (isPlaying && indicatorRef.current) {
+      indicatorAnim.current = animate(indicatorRef.current, {
+        opacity: [0.6, 1],
+        scale: [1, 1.05],
+        direction: 'alternate',
+        easing: 'easeInOutSine',
+        duration: 800,
+        loop: true
+      })
+    }
+  }, [isPlaying])
+
   return (
-    <div className="video-player">
-      <img 
-        className="tv-placeholder" 
-        src="https://placehold.co/1432x807/333333/ffffff?text=Video+Player" 
-        alt="Video Player Placeholder" 
+    <div className="video-player" ref={containerRef}>
+      <img
+        className="tv-placeholder"
+        src="https://placehold.co/1432x807/333333/ffffff?text=Video+Player"
+        alt="Video Player Placeholder"
       />
-      {/* You can add a play indicator overlay here if needed */}
       {isPlaying && (
-        <div className="playing-indicator" style={{
-          position: 'absolute',
-          top: '10px',
-          right: '10px',
-          background: 'rgba(0,0,0,0.7)',
-          color: 'white',
-          padding: '4px 8px',
-          borderRadius: '4px',
-          fontSize: '12px'
-        }}>
+        <div
+          ref={indicatorRef}
+          className="playing-indicator"
+          style={{
+            position: 'absolute',
+            top: '10px',
+            right: '10px',
+            background: 'rgba(0,0,0,0.7)',
+            color: 'white',
+            padding: '4px 8px',
+            borderRadius: '4px',
+            fontSize: '12px'
+          }}
+        >
           Playing
         </div>
       )}


### PR DESCRIPTION
## Summary
- Integrate anime.js animations for video player fade-in and pulsing play indicator
- Animate control bar progress and play/pause button with spring easing
- Stagger menu buttons and slide chat panel/messages for polished transitions
- Keep video player mounted while toggling chat to prevent white flash

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3926e53708325b4ffab38925983be