### PR TITLE
Add subtle anime.js animations to player

### DIFF
--- a/src/components/ChatSection.css
+++ b/src/components/ChatSection.css
@@ -12,9 +12,10 @@
   flex-direction: column;
   gap: 12px;
   min-height: 0;
-  position: relative;
-  margin: 0 auto;
-}
+    position: relative;
+    margin: 0 auto;
+    opacity: 0;
+  }
 
 .close-button-wrapper {
   display: flex;

--- a/src/components/ChatSection.tsx
+++ b/src/components/ChatSection.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { animate } from 'animejs'
 import './ChatSection.css'
 
 interface Message {
@@ -9,11 +10,39 @@ interface Message {
 
 interface ChatSectionProps {
   height?: number
+  isVisible: boolean
+  onRequestClose: () => void
+  onClosed: () => void
 }
 
-const ChatSection = ({ height }: ChatSectionProps) => {
+const ChatSection = ({ height, isVisible, onRequestClose, onClosed }: ChatSectionProps) => {
   const [messages, setMessages] = useState<Message[]>([])
   const [inputValue, setInputValue] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const messagesRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      animate(containerRef.current, {
+        translateX: [40, 0],
+        opacity: [0, 1],
+        easing: 'easeOutQuad',
+        duration: 400
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isVisible && containerRef.current) {
+      animate(containerRef.current, {
+        translateX: [0, 40],
+        opacity: [1, 0],
+        easing: 'easeInQuad',
+        duration: 300,
+        complete: onClosed
+      })
+    }
+  }, [isVisible, onClosed])
 
   const handleSendMessage = () => {
     if (inputValue.trim()) {
@@ -35,11 +64,24 @@ const ChatSection = ({ height }: ChatSectionProps) => {
 
   const chatStyle = height ? { height: `${height}px` } : {}
   
+  useEffect(() => {
+    if (messagesRef.current) {
+      const last = messagesRef.current.lastElementChild
+      if (last) {
+        animate(last as Element, {
+          translateX: [50, 0],
+          opacity: [0, 1],
+          easing: 'easeOutQuad'
+        })
+      }
+    }
+  }, [messages])
+
   return (
-    <div className="chat-section" style={chatStyle}>
+    <div className="chat-section" style={chatStyle} ref={containerRef}>
       {/* Close button */}
       <div className="close-button-wrapper">
-        <div className="close-button">
+        <div className="close-button" onClick={onRequestClose}>
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M13 1L1 13M1 1L13 13" stroke="#999" strokeWidth="2" strokeLinecap="round"/>
           </svg>
@@ -47,7 +89,7 @@ const ChatSection = ({ height }: ChatSectionProps) => {
       </div>
 
       {/* Messages container */}
-      <div className="messages-container">
+      <div className="messages-container" ref={messagesRef}>
         {messages.map((message) => (
           <div key={message.id} className={`chat-message ${message.isOwn ? 'right' : 'left'}`}>
             <div className={`message-bubble ${message.isOwn ? 'green' : 'blue'}`}>

--- a/src/components/MediaSelector.css
+++ b/src/components/MediaSelector.css
@@ -1,0 +1,15 @@
+.media-selector {
+  width: 100%;
+  background: rgba(72, 72, 72, 0.4);
+  border-radius: 8px;
+  padding: 10px;
+  box-shadow: inset 0 1px 5px rgba(0, 0, 0, 0.25);
+}
+
+.media-item {
+  background: rgba(0, 0, 0, 0.2);
+  color: #cecece;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+}

--- a/src/components/MediaSelector.tsx
+++ b/src/components/MediaSelector.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+import { animate } from 'animejs'
+import './MediaSelector.css'
+
+interface MediaSelectorProps {
+  isVisible: boolean
+}
+
+const MediaSelector = ({ isVisible }: MediaSelectorProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      const el = containerRef.current
+      if (isVisible) {
+        el.style.display = 'flex'
+        const fullHeight = el.scrollHeight
+        animate(el, {
+          height: [0, fullHeight],
+          opacity: [0, 1],
+          duration: 300,
+          easing: 'easeOutQuad'
+        })
+      } else {
+        const fullHeight = el.scrollHeight
+        animate(el, {
+          height: [fullHeight, 0],
+          opacity: [1, 0],
+          duration: 300,
+          easing: 'easeInQuad',
+          complete: () => {
+            el.style.display = 'none'
+          }
+        })
+      }
+    }
+  }, [isVisible])
+
+  return (
+    <div className="media-selector" ref={containerRef} style={{ display: 'none', overflow: 'hidden', flexDirection: 'column', gap: '8px' }}>
+      <div className="media-item">Media Placeholder 1</div>
+      <div className="media-item">Media Placeholder 2</div>
+      <div className="media-item">Media Placeholder 3</div>
+    </div>
+  )
+}
+
+export default MediaSelector

--- a/src/components/MenuBar.css
+++ b/src/components/MenuBar.css
@@ -17,8 +17,12 @@
   gap: 30px;
 }
 
+.menu-bar button {
+  opacity: 0;
+}
+
 .home-button,
-.more-videos-button,
+.media-button,
 .chat-button {
   background: none;
   border: none;
@@ -87,64 +91,6 @@
   opacity: 0.74;
 }
 
-.more-videos-button {
-  width: 45px;
-  height: 45px;
-  padding: 0;
-  overflow: hidden;
-  border-radius: 5px;
-  border: none;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  position: relative;
-  z-index: 2;
-}
-
-.more-videos-button:hover {
-  width: 174px;
-}
-
-.more-videos-button:not(:hover) {
-  width: 45px;
-}
-
-.more-videos-icon {
-  opacity: 1;
-  transition: opacity 0.3s ease;
-  z-index: 3;
-  position: relative;
-}
-
-.more-videos-button:hover .more-videos-icon {
-  opacity: 0;
-}
-
-.more-videos-hovered {
-  width: 100%;
-  height: 39px;
-  padding: 7px 25px;
-  opacity: 0;
-  background: rgba(72.41, 72.41, 72.41, 0.82);
-  box-shadow: 1px 1px 3px rgba(29, 29, 29, 0.90) inset;
-  border-radius: 5px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  z-index: 1;
-  transition: opacity 0.3s ease;
-}
-
-.more-videos-button:hover .more-videos-hovered {
-  opacity: 0.74;
-}
-
-.more-videos-hovered span,
 .home-hovered span {
   text-align: center;
   color: #CECECE;
@@ -173,4 +119,20 @@
 
 .chat-button.active svg g {
   opacity: 1;
+}
+
+.right-side {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.media-button {
+  width: 45px;
+  height: 45px;
+  transition: transform 0.2s ease;
+}
+
+.media-button:hover {
+  transform: scale(1.05);
 }

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,13 +1,31 @@
+import { useEffect, useRef } from 'react'
+import { animate, stagger } from 'animejs'
 import './MenuBar.css'
 
 interface MenuBarProps {
   onChatToggle: () => void
   isChatVisible: boolean
+  onMediaToggle: () => void
+  isMediaVisible: boolean
 }
 
-const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
+const MenuBar = ({ onChatToggle, isChatVisible, onMediaToggle, isMediaVisible }: MenuBarProps) => {
+  const menuBarRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (menuBarRef.current) {
+      const buttons = menuBarRef.current.querySelectorAll('button')
+      animate(buttons, {
+        opacity: [0, 1],
+        translateY: [-8, 0],
+        easing: 'easeOutQuad',
+        delay: stagger(80)
+      })
+    }
+  }, [])
+
   return (
-    <div className="menu-bar">
+    <div className="menu-bar" ref={menuBarRef}>
       <div className="left-side">
         <button className="home-button">
           <svg className="home-icon" width="47" height="45" viewBox="0 0 47 45" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -59,9 +77,14 @@ const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
           <div className="home-hovered">
             <span>Home</span>
           </div>
-        </button>
-        
-        <button className="more-videos-button">
+          </button>
+      </div>
+
+      <div className="right-side">
+        <button
+          className={`media-button ${isMediaVisible ? 'active' : ''}`}
+          onClick={onMediaToggle}
+        >
           <svg className="more-videos-icon" width="45" height="45" viewBox="0 0 45 45" fill="none" xmlns="http://www.w3.org/2000/svg">
             <g opacity="0.74" filter="url(#filter0_ddiiii_1_19081)">
               <rect x="3" y="3" width="38.9679" height="39" rx="5" fill="#484848" fillOpacity="0.82"/>
@@ -108,24 +131,20 @@ const MenuBar = ({ onChatToggle, isChatVisible }: MenuBarProps) => {
               </filter>
             </defs>
           </svg>
-          <div className="more-videos-hovered">
-            <span>More Videos</span>
-          </div>
+        </button>
+        <button
+          className={`chat-button ${isChatVisible ? 'active' : ''}`}
+          onClick={onChatToggle}
+        >
+          <svg width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <g opacity={isChatVisible ? '1' : '0.45'}>
+              <path opacity="0.64" d="M15 28C21.9036 28 27.5 22.4036 27.5 15.5C27.5 8.59644 21.9036 3 15 3C8.09644 3 2.5 8.59644 2.5 15.5C2.5 17.4996 2.96952 19.3895 3.80433 21.0656C4.02617 21.511 4.10001 22.0201 3.9714 22.5008L3.22689 25.2833C2.90369 26.4912 4.00877 27.5963 5.21668 27.2731L7.99923 26.5286C8.47992 26.4 8.98901 26.4738 9.43441 26.6957C11.1105 27.5305 13.0004 28 15 28Z" fill="#484848" fillOpacity="0.78"/>
+              <path d="M9.78125 16.5625C9.21171 16.5625 8.75 17.0242 8.75 17.5937C8.75 18.1633 9.21171 18.625 9.78125 18.625H17.3438C17.9133 18.625 18.375 18.1633 18.375 17.5937C18.375 17.0242 17.9133 16.5625 17.3438 16.5625H9.78125Z" fill="black"/>
+              <path d="M9.78125 11.75C9.21171 11.75 8.75 12.2117 8.75 12.7812C8.75 13.3508 9.21171 13.8125 9.78125 13.8125H20.7812C21.3508 13.8125 21.8125 13.3508 21.8125 12.7812C21.8125 12.2117 21.3508 11.75 20.7812 11.75H9.78125Z" fill="black"/>
+            </g>
+          </svg>
         </button>
       </div>
-      
-      <button 
-        className={`chat-button ${isChatVisible ? 'active' : ''}`} 
-        onClick={onChatToggle}
-      >
-        <svg width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <g opacity={isChatVisible ? "1" : "0.45"}>
-            <path opacity="0.64" d="M15 28C21.9036 28 27.5 22.4036 27.5 15.5C27.5 8.59644 21.9036 3 15 3C8.09644 3 2.5 8.59644 2.5 15.5C2.5 17.4996 2.96952 19.3895 3.80433 21.0656C4.02617 21.511 4.10001 22.0201 3.9714 22.5008L3.22689 25.2833C2.90369 26.4912 4.00877 27.5963 5.21668 27.2731L7.99923 26.5286C8.47992 26.4 8.98901 26.4738 9.43441 26.6957C11.1105 27.5305 13.0004 28 15 28Z" fill="#484848" fillOpacity="0.78"/>
-            <path d="M9.78125 16.5625C9.21171 16.5625 8.75 17.0242 8.75 17.5937C8.75 18.1633 9.21171 18.625 9.78125 18.625H17.3438C17.9133 18.625 18.375 18.1633 18.375 17.5937C18.375 17.0242 17.9133 16.5625 17.3438 16.5625H9.78125Z" fill="black"/>
-            <path d="M9.78125 11.75C9.21171 11.75 8.75 12.2117 8.75 12.7812C8.75 13.3508 9.21171 13.8125 9.78125 13.8125H20.7812C21.3508 13.8125 21.8125 13.3508 21.8125 12.7812C21.8125 12.2117 21.3508 11.75 20.7812 11.75H9.78125Z" fill="black"/>
-          </g>
-        </svg>
-      </button>
     </div>
   )
 }

--- a/src/components/VideoControls.css
+++ b/src/components/VideoControls.css
@@ -17,19 +17,34 @@
   position: relative;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .video-progress svg {
   width: 100%;
   height: 2px;
+  pointer-events: none;
 }
 
 .video-position {
   position: absolute;
-  left: 0;
   top: 50%;
-  transform: translateY(-50%);
+  left: 0;
+  width: 12px;
+  height: 12px;
+  background: #6a7967;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  pointer-events: none;
+  opacity: 0.8;
   z-index: 2;
+}
+
+.video-progress:hover .video-position {
+  transform: translate(-50%, -50%) scale(1.3);
+  opacity: 1;
 }
 
 .play-pause-button {

--- a/src/components/VideoControls.tsx
+++ b/src/components/VideoControls.tsx
@@ -1,49 +1,102 @@
+import { useEffect, useRef, useState } from 'react'
+import { animate } from 'animejs'
 import './VideoControls.css'
 
 interface VideoControlsProps {
   isPlaying: boolean
   onTogglePlayPause: () => void
+  videoRef: React.MutableRefObject<HTMLVideoElement | null>
 }
 
-const VideoControls = ({ isPlaying, onTogglePlayPause }: VideoControlsProps) => {
+const VideoControls = ({ isPlaying, onTogglePlayPause, videoRef }: VideoControlsProps) => {
+  const progressBarRef = useRef<HTMLDivElement>(null)
+  const progressRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [progress, setProgress] = useState(0)
+  const [isScrubbing, setIsScrubbing] = useState(false)
+
+  useEffect(() => {
+    const vid = videoRef.current
+    if (!vid) return
+    const update = () => {
+      if (!isScrubbing) {
+        const pct = vid.duration ? vid.currentTime / vid.duration : 0
+        setProgress(pct)
+      }
+    }
+    vid.addEventListener('timeupdate', update)
+    return () => vid.removeEventListener('timeupdate', update)
+  }, [videoRef, isScrubbing])
+
+  const handleScrub = (clientX: number) => {
+    if (!progressBarRef.current || !videoRef.current) return
+    const rect = progressBarRef.current.getBoundingClientRect()
+    const pos = Math.min(Math.max(0, clientX - rect.left), rect.width)
+    const pct = pos / rect.width
+    videoRef.current.currentTime = pct * (videoRef.current.duration || 0)
+    setProgress(pct)
+  }
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    setIsScrubbing(true)
+    handleScrub(e.clientX)
+  }
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (isScrubbing) handleScrub(e.clientX)
+  }
+  const endScrub = (e: React.PointerEvent) => {
+    if (isScrubbing) {
+      handleScrub(e.clientX)
+      setIsScrubbing(false)
+    }
+  }
+
+  useEffect(() => {
+    if (buttonRef.current) {
+      animate(buttonRef.current, {
+        scale: [0.9, 1],
+        easing: 'spring(1, 80, 10, 0)',
+        duration: 500
+      })
+    }
+  }, [isPlaying])
+
+  useEffect(() => {
+    if (progressRef.current && progressBarRef.current) {
+      const width = progressBarRef.current.clientWidth
+      animate(progressRef.current, {
+        left: progress * width,
+        duration: 150,
+        easing: 'linear'
+      })
+    }
+  }, [progress])
+
   return (
     <div className="video-controls">
-      <div className="video-progress">
-        <svg width="1422" height="2" viewBox="0 0 1422 2" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M1.70755 1H1420.96" stroke="#4D413F" strokeWidth="2" strokeLinecap="round"/>
+      <div
+        className="video-progress"
+        ref={progressBarRef}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endScrub}
+        onPointerLeave={endScrub}
+      >
+        <svg width="100%" height="2" viewBox="0 0 1422 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M1.70755 1H1420.96" stroke="#4D413F" strokeWidth="2" strokeLinecap="round" />
         </svg>
-        <div className="video-position">
-          <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <g filter="url(#filter0_d_1_19743)">
-              <ellipse cx="6.38295" cy="6.38295" rx="6.38295" ry="6.38295" transform="matrix(-1 0 0 1 15.811 0.617065)" fill="#6A7967"/>
-            </g>
-            <defs>
-              <filter id="filter0_d_1_19743" x="0.745105" y="0.617065" width="17.3659" height="18.0659" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
-                <feFlood floodOpacity="0" result="BackgroundImageFix"/>
-                <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-                <feOffset dy="3"/>
-                <feGaussianBlur stdDeviation="1.15"/>
-                <feComposite in2="hardAlpha" operator="out"/>
-                <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-                <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_19743"/>
-                <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_19743" result="shape"/>
-              </filter>
-            </defs>
-          </svg>
-        </div>
+        <div className="video-position" ref={progressRef} />
       </div>
-      
-      <button className="play-pause-button" onClick={onTogglePlayPause}>
+
+      <button className="play-pause-button" onClick={onTogglePlayPause} ref={buttonRef}>
         {isPlaying ? (
-          // Pause icon (two bars) - taller and perfectly centered
           <svg width="48" height="24" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="18.2" y="4" width="3.6" height="16" rx="1.8" fill="#5D5D5D"/>
-            <rect x="26.2" y="4" width="3.6" height="16" rx="1.8" fill="#5D5D5D"/>
+            <rect x="18.2" y="4" width="3.6" height="16" rx="1.8" fill="#5D5D5D" />
+            <rect x="26.2" y="4" width="3.6" height="16" rx="1.8" fill="#5D5D5D" />
           </svg>
         ) : (
-          // Play icon (triangle) - taller and centered
           <svg width="48" height="24" viewBox="0 0 48 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16.6 4L31.4 12L16.6 20V4Z" fill="#5D5D5D"/>
+            <path d="M16.6 4L31.4 12L16.6 20V4Z" fill="#5D5D5D" />
           </svg>
         )}
       </button>

--- a/src/components/VideoPartyScreen.tsx
+++ b/src/components/VideoPartyScreen.tsx
@@ -1,59 +1,127 @@
 import { useState, useRef, useEffect } from 'react'
+import { animate } from 'animejs'
 import './VideoPartyScreen.css'
 import MenuBar from './MenuBar.tsx'
 import VideoPlayer from './VideoPlayer.tsx'
 import VideoControls from './VideoControls.tsx'
 import ChatSection from './ChatSection.tsx'
+import MediaSelector from './MediaSelector.tsx'
 
 const VideoPartyScreen = () => {
   const [isChatVisible, setIsChatVisible] = useState(false)
+  const [shouldRenderChat, setShouldRenderChat] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
   const [chatHeight, setChatHeight] = useState<number | undefined>(undefined)
+  const [isMediaVisible, setIsMediaVisible] = useState(false)
   const mediaItemsRef = useRef<HTMLDivElement>(null)
+  const videoRef = useRef<HTMLVideoElement>(null)
 
   const toggleChat = () => {
-    setIsChatVisible(!isChatVisible)
+    if (isChatVisible) {
+      setIsChatVisible(false)
+    } else {
+      setShouldRenderChat(true)
+      setIsChatVisible(true)
+    }
+  }
+
+  const toggleMedia = () => {
+    setIsMediaVisible(!isMediaVisible)
+  }
+
+  const handleChatClosed = () => {
+    setShouldRenderChat(false)
   }
 
   const togglePlayPause = () => {
-    setIsPlaying(!isPlaying)
+    setIsPlaying(prev => !prev)
   }
 
   useEffect(() => {
-    if (isChatVisible && mediaItemsRef.current) {
+    if (shouldRenderChat && mediaItemsRef.current) {
       const updateChatHeight = () => {
         if (mediaItemsRef.current) {
           const rect = mediaItemsRef.current.getBoundingClientRect()
           setChatHeight(rect.height)
         }
       }
-      
+
       updateChatHeight()
       window.addEventListener('resize', updateChatHeight)
-      
+
       return () => window.removeEventListener('resize', updateChatHeight)
     }
+  }, [shouldRenderChat, isMediaVisible])
+
+  useEffect(() => {
+    if (mediaItemsRef.current) {
+      animate(mediaItemsRef.current, {
+        translateX: isChatVisible ? -20 : 0,
+        scale: isChatVisible ? 0.98 : 1,
+        duration: 400,
+        easing: 'easeOutQuad'
+      })
+    }
   }, [isChatVisible])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        e.preventDefault()
+        setIsPlaying(prev => !prev)
+      } else if (e.code === 'ArrowLeft') {
+        if (videoRef.current) {
+          videoRef.current.currentTime = Math.max(
+            0,
+            videoRef.current.currentTime - 10
+          )
+        }
+      } else if (e.code === 'ArrowRight') {
+        if (videoRef.current) {
+          videoRef.current.currentTime = Math.min(
+            videoRef.current.duration || 0,
+            videoRef.current.currentTime + 10
+          )
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [])
 
   return (
     <div className="netflix-party-screen">
       <div className={`screen-container ${isChatVisible ? 'chat-visible' : 'chat-hidden'}`}>
-        <MenuBar onChatToggle={toggleChat} isChatVisible={isChatVisible} />
-        
-        {isChatVisible ? (
-          <div className="horizontal-wrapper">
-            <div className="media-items" ref={mediaItemsRef}>
-              <VideoPlayer isPlaying={isPlaying} />
-              <VideoControls isPlaying={isPlaying} onTogglePlayPause={togglePlayPause} />
-            </div>
-            <ChatSection height={chatHeight} />
+        <MenuBar
+          onChatToggle={toggleChat}
+          isChatVisible={isChatVisible}
+          onMediaToggle={toggleMedia}
+          isMediaVisible={isMediaVisible}
+        />
+
+        <div className="horizontal-wrapper">
+          <div
+            className={`media-items ${isChatVisible ? '' : 'fullscreen'}`}
+            ref={mediaItemsRef}
+          >
+            <VideoPlayer isPlaying={isPlaying} videoRef={videoRef} />
+            <VideoControls
+              isPlaying={isPlaying}
+              onTogglePlayPause={togglePlayPause}
+              videoRef={videoRef}
+            />
+            <MediaSelector isVisible={isMediaVisible} />
           </div>
-        ) : (
-          <div className="media-items fullscreen">
-            <VideoPlayer isPlaying={isPlaying} />
-            <VideoControls isPlaying={isPlaying} onTogglePlayPause={togglePlayPause} />
-          </div>
-        )}
+          {shouldRenderChat && (
+            <ChatSection
+              height={chatHeight}
+              isVisible={isChatVisible}
+              onRequestClose={() => setIsChatVisible(false)}
+              onClosed={handleChatClosed}
+            />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/VideoPlayer.css
+++ b/src/components/VideoPlayer.css
@@ -1,13 +1,14 @@
-.video-player {
-  width: 100%;
-  max-width: calc(72vh * 16 / 9); /* Increased from 60vh to 72vh for 20% bigger */
-  box-shadow: 5px 5px 13px rgba(102, 102, 102, 0.90);
-  background: #000;
-  border-radius: 8px;
-  overflow: hidden;
-  position: relative;
-  margin: 0 auto; /* Center the video player when it's constrained */
-}
+  .video-player {
+    width: 100%;
+    max-width: calc(72vh * 16 / 9); /* Increased from 60vh to 72vh for 20% bigger */
+    box-shadow: 5px 5px 13px rgba(102, 102, 102, 0.90);
+    background: #000;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    margin: 0 auto; /* Center the video player when it's constrained */
+    opacity: 0;
+  }
 
 .video-player::before {
   content: "";
@@ -16,12 +17,11 @@
   padding-top: 56.25%; /* 16:9 aspect ratio (9/16 * 100) */
 }
 
-.tv-placeholder {
+.video-element {
   width: 100%;
   height: 100%;
-  border-radius: 8px;
-  object-fit: cover;
   position: absolute;
   top: 0;
   left: 0;
+  object-fit: cover;
 }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,29 +1,74 @@
+import { useEffect, useRef } from 'react'
+import { animate } from 'animejs'
 import './VideoPlayer.css'
 
 interface VideoPlayerProps {
   isPlaying: boolean
+  videoRef: React.MutableRefObject<HTMLVideoElement | null>
 }
 
-const VideoPlayer = ({ isPlaying }: VideoPlayerProps) => {
+const VideoPlayer = ({ isPlaying, videoRef }: VideoPlayerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const indicatorRef = useRef<HTMLDivElement>(null)
+  const indicatorAnim = useRef<ReturnType<typeof animate> | null>(null)
+
+  useEffect(() => {
+    if (containerRef.current) {
+      animate(containerRef.current, {
+        opacity: [0, 1],
+        scale: [0.96, 1],
+        easing: 'easeOutQuad',
+        duration: 600
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    indicatorAnim.current?.cancel()
+    if (isPlaying && indicatorRef.current) {
+      indicatorAnim.current = animate(indicatorRef.current, {
+        opacity: [0.6, 1],
+        scale: [1, 1.05],
+        direction: 'alternate',
+        easing: 'easeInOutSine',
+        duration: 800,
+        loop: true
+      })
+    }
+  }, [isPlaying])
+
+  useEffect(() => {
+    if (videoRef.current) {
+      if (isPlaying) {
+        videoRef.current.play()
+      } else {
+        videoRef.current.pause()
+      }
+    }
+  }, [isPlaying, videoRef])
+
   return (
-    <div className="video-player">
-      <img 
-        className="tv-placeholder" 
-        src="https://placehold.co/1432x807/333333/ffffff?text=Video+Player" 
-        alt="Video Player Placeholder" 
+    <div className="video-player" ref={containerRef}>
+      <video
+        ref={videoRef}
+        className="video-element"
+        src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4"
       />
-      {/* You can add a play indicator overlay here if needed */}
       {isPlaying && (
-        <div className="playing-indicator" style={{
-          position: 'absolute',
-          top: '10px',
-          right: '10px',
-          background: 'rgba(0,0,0,0.7)',
-          color: 'white',
-          padding: '4px 8px',
-          borderRadius: '4px',
-          fontSize: '12px'
-        }}>
+        <div
+          ref={indicatorRef}
+          className="playing-indicator"
+          style={{
+            position: 'absolute',
+            top: '10px',
+            right: '10px',
+            background: 'rgba(0,0,0,0.7)',
+            color: 'white',
+            padding: '4px 8px',
+            borderRadius: '4px',
+            fontSize: '12px'
+          }}
+        >
           Playing
         </div>
       )}


### PR DESCRIPTION
## Summary
- Enable progress bar scrubbing with a tiny animated playback head
- Support spacebar play/pause and arrow key seeking, while video shifts when chat toggles
- Add toggleable media selector panel with placeholder items and menu bar button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3926e53708325b4ffab38925983be