### PR TITLE
Add basic login gate before video player

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'Password Screen/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,15 @@
+import { useState } from 'react'
 import './App.css'
 import VideoPartyScreen from './components/VideoPartyScreen.tsx'
+import LoginScreen from './components/LoginScreen.tsx'
 
 function App() {
+  const [loggedIn, setLoggedIn] = useState(false)
+
+  if (!loggedIn) {
+    return <LoginScreen onLogin={() => setLoggedIn(true)} />
+  }
+
   return (
     <div className="app">
       <VideoPartyScreen />

--- a/src/components/LoginScreen.css
+++ b/src/components/LoginScreen.css
@@ -1,0 +1,25 @@
+.login-screen {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.user-list {
+  display: flex;
+  gap: 1rem;
+}
+
+.password-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.error {
+  color: red;
+  font-size: 0.875rem;
+}

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import './LoginScreen.css'
+
+const USERS = ['Avalene', 'Fred']
+const PASSWORD = 'password'
+
+interface LoginScreenProps {
+  onLogin: () => void
+}
+
+export default function LoginScreen({ onLogin }: LoginScreenProps) {
+  const [selectedUser, setSelectedUser] = useState<string | null>(null)
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (password === PASSWORD) {
+      onLogin()
+    } else {
+      setError('Incorrect password')
+    }
+  }
+
+  if (!selectedUser) {
+    return (
+      <div className="login-screen">
+        <h1>Who's Watching...</h1>
+        <div className="user-list">
+          {USERS.map(user => (
+            <button
+              key={user}
+              onClick={() => {
+                setSelectedUser(user)
+                setPassword('')
+                setError('')
+              }}
+            >
+              {user}
+            </button>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="login-screen">
+      <button
+        className="back-button"
+        onClick={() => {
+          setSelectedUser(null)
+          setPassword('')
+          setError('')
+        }}
+      >
+        Back
+      </button>
+      <h2>Hi {selectedUser}...</h2>
+      <form onSubmit={handleSubmit} className="password-form">
+        <label>
+          Password:
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+        </label>
+        {error && <div className="error">{error}</div>}
+        <button type="submit" disabled={!password}>
+          Login
+        </button>
+      </form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add simple login flow with user selection and password entry
- gate VideoPartyScreen behind login
- update ESLint config to ignore prototype password screen files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3af457e008325ac1fb671a83f34b3